### PR TITLE
Update swiftBinDefault to use v5.7

### DIFF
--- a/src/main.swift
+++ b/src/main.swift
@@ -162,9 +162,9 @@ func parsePath(_ argument: String, relativeTo basePath: URL) -> URL? {
 }
 
 #if os(macOS)
-let swiftBinDefault = "/Users/runner/hostedtoolcache/swift-macOS/5.6.3/x64/usr/bin/swift"
+let swiftBinDefault = "/Users/runner/hostedtoolcache/swift-macOS/5.7/x64/usr/bin/swift"
 #else
-let swiftBinDefault = "/opt/hostedtoolcache/swift-Ubuntu/5.6.3/x64/usr/bin/swift"
+let swiftBinDefault = "/opt/hostedtoolcache/swift-Ubuntu/5.7/x64/usr/bin/swift"
 #endif
 let swiftBin = parseArg("--swift-bin") ?? swiftBinDefault
 print(swiftBin)


### PR DESCRIPTION
This will allow for the use on packages using swift version 5.7.